### PR TITLE
Add dit URLs to MAAP System Status Page

### DIFF
--- a/urls.cfg
+++ b/urls.cfg
@@ -1,7 +1,11 @@
 stac_api=https://stac.maap-project.org/ping
+stac_api_dit=https://stac.dit.maap-project.org/ping
 titiler_eoapi=https://titiler-pgstac.maap-project.org/ping
+titiler_eoapi_dit=https://titiler-pgstac.dit.maap-project.org/ping
 titiler_impact=https://titiler.maap-project.org/healthz
+titiler_impact_dit=https://titiler.dit.maap-project.org/healthz
 ingestor_api=https://stac-ingestor.maap-project.org/ping
+ingestor_api_dit=https://stac-ingestor.dit.maap-project.org/ping
 stac_browser=https://stac-browser.maap-project.org/api
 community=https://github.com/orgs/MAAP-Project/discussions
 maap_api=https://api.maap-project.org/api


### PR DESCRIPTION
Based on this - https://github.com/NASA-IMPACT/active-maap-sprint/issues/811#issuecomment-1850753774, new `dit` URLs have been added to the MAAP status page.