### PR TITLE
chore: add maap hubs health

### DIFF
--- a/urls.cfg
+++ b/urls.cfg
@@ -1,3 +1,5 @@
+maap_hub=https://hub.maap-project.org/hub/health
+maap_hub_staging=https://staging.hub.maap-project.org/hub/health
 stac_api=https://stac.maap-project.org/ping
 stac_api_dit=https://stac.dit.maap-project.org/ping
 titiler_eoapi=https://titiler-pgstac.maap-project.org/ping
@@ -15,4 +17,3 @@ biomass_harmonization_dashboard=https://biomass.maap-project.org
 maap_ade=https://ade.maap-project.org
 maap_project_website=https://maap-project.org
 maap_dps=https://api.maap-project.org/api/dps/job
-


### PR DESCRIPTION
## Changes
- adds the production and staging urls for the hubs - [2i2c docs](https://infrastructure.2i2c.org/topic/monitoring-alerting/uptime-checks-alerts/#jupyterhub-health-checks)